### PR TITLE
fix(event.key): use event.key instead of event.code

### DIFF
--- a/src/SecretCode/useInputEvent.js
+++ b/src/SecretCode/useInputEvent.js
@@ -4,7 +4,7 @@ export const useInputEvent = () => {
 	const [key, setKey] = useState(null);
 
 	useEffect(() => {
-		const keyDownHandler = ({ code }) => setKey(code);
+		const keyDownHandler = ({ key }) => setKey(key);
 		const keyUpHandler = () => setKey(null);
 
 		global.addEventListener("keydown", keyDownHandler);

--- a/src/SecretCode/useKonamiCode.js
+++ b/src/SecretCode/useKonamiCode.js
@@ -11,8 +11,8 @@ const konamiCode = [
 	"ArrowRight",
 	"ArrowLeft",
 	"ArrowRight",
-	"KeyB",
-	"KeyA",
+	"b",
+	"a",
 ];
 
 export const useKonamiCode = () => {


### PR DESCRIPTION
event.code return the physical code of the keyboard, so it can change depending on you keyboard layout . 

Using event.key will provide the real key pressed .

to illustrate, on an azerty keyboard, pressing `A` : 
```js
{ 
    "altKey": false,
    "charCode": 0,
    "code": "KeyQ", //the physical key
    "ctrlKey": false,
    "key": "a", //the logical key (depending of the layout)
    "keyCode": 65,
    "which": 65 
}
```

Fix #1 